### PR TITLE
Add test action to log PR event data

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
+            const core = require('@actions/core');
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
 

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,69 @@
+name: Perform a code review when a pull request is created.
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened]
+
+jobs:
+  codex:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Explicitly check out the PR's merge commit.
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Pre-fetch base and head refs for the PR
+        run: |
+          git fetch --no-tags origin \
+            ${{ github.event.pull_request.base.ref }} \
+            +refs/pull/${{ github.event.pull_request.number }}/head
+
+      # If you want Codex to build and run code, install any dependencies that
+      # need to be downloaded before the "Run Codex" step because Codex's
+      # default sandbox disables network access.
+
+      - name: Run Codex
+        id: run_codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt: |
+            This is PR #${{ github.event.pull_request.number }} for ${{ github.repository }}.
+            Base SHA: ${{ github.event.pull_request.base.sha }}
+            Head SHA: ${{ github.event.pull_request.head.sha }}
+
+            Review ONLY the changes introduced by the PR.
+            Suggest any improvements, potential bugs, or issues.
+            Be concise and specific in your feedback.
+
+            Pull request title and body:
+            ----
+            ${{ github.event.pull_request.title }}
+            ${{ github.event.pull_request.body }}
+
+  post_feedback:
+    runs-on: ubuntu-latest
+    needs: codex
+    if: needs.codex.outputs.final_message != ''
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Report Codex feedback
+        uses: actions/github-script@v7
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.CODEX_FINAL_MESSAGE,
+            });

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     outputs:
-      codex_json: ${{ steps.run_codex.outputs.final-message }}
+      codex_json: ${{ steps.run_codex.outputs['final-message'] }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   codex:
     runs-on: ubuntu-latest
@@ -80,7 +84,7 @@ jobs:
           script: |
             const warn = (msg) =>
               (typeof core !== 'undefined' && core?.warning)
-                ? warn(msg)
+                ? core.warning(msg)
                 : console.warn(msg);
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -2,7 +2,7 @@ name: Codex PR Review (inline)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, review_requested, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   codex:
+    if: ${{ !contains(fromJSON('["develop","weekly","main"]'), github.head_ref) || (github.event.action == 'review_requested' && github.event.requested_reviewer && github.event.requested_reviewer.login == 'Copilot') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -78,7 +78,10 @@ jobs:
         with:
           github-token: ${{ github.token }}
           script: |
-            const core = require('@actions/core');
+            const warn = (msg) =>
+              (typeof core !== 'undefined' && core?.warning)
+                ? warn(msg)
+                : console.warn(msg);
             const prNumber = context.payload.pull_request.number;
             const headSha = context.payload.pull_request.head.sha;
 
@@ -145,10 +148,10 @@ jobs:
                     }
                     // Skip not in diff
                     if (String(err?.message || '').includes('position') || String(err?.message || '').includes('line must be part of the diff')) {
-                      core.warning(`Skip ${c.path}:${c.line} — not in diff`);
+                      warn(`Skip ${c.path}:${c.line} — not in diff`);
                       break;
                     }
-                    core.warning(`Failed ${c.path}:${c.line}: ${err?.message || err}`);
+                    warn(`Failed ${c.path}:${c.line}: ${err?.message || err}`);
                     break;
                   }
                 }

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,8 +1,8 @@
-name: Perform a code review when a pull request is created.
+name: Codex PR Review (inline)
+
 on:
-  workflow_dispatch:
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   codex:
@@ -10,11 +10,10 @@ jobs:
     permissions:
       contents: read
     outputs:
-      final_message: ${{ steps.run_codex.outputs.final-message }}
+      codex_json: ${{ steps.run_codex.outputs.final-message }}
     steps:
       - uses: actions/checkout@v5
         with:
-          # Explicitly check out the PR's merge commit.
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Pre-fetch base and head refs for the PR
@@ -22,10 +21,6 @@ jobs:
           git fetch --no-tags origin \
             ${{ github.event.pull_request.base.ref }} \
             +refs/pull/${{ github.event.pull_request.number }}/head
-
-      # If you want Codex to build and run code, install any dependencies that
-      # need to be downloaded before the "Run Codex" step because Codex's
-      # default sandbox disables network access.
 
       - name: Run Codex
         id: run_codex
@@ -37,33 +32,124 @@ jobs:
             Base SHA: ${{ github.event.pull_request.base.sha }}
             Head SHA: ${{ github.event.pull_request.head.sha }}
 
-            Review ONLY the changes introduced by the PR.
-            Suggest any improvements, potential bugs, or issues.
-            Be concise and specific in your feedback.
+            Review ONLY the diff introduced by this PR. Be concise and specific.
+            Produce STRICT MINIFIED JSON (no backticks, no code fences, no extra text):
+            {
+              "summary": "one-paragraph summary of key findings",
+              "comments": [
+                {
+                  "path": "relative/path/from/repo/root.ext",
+                  "line": 123,               // line number on HEAD (new) side
+                  "title": "Short label",     // optional
+                  "body": "Clear, actionable feedback. Include suggestion/fix if possible."
+                }
+              ]
+            }
 
-            Pull request title and body:
-            ----
-            ${{ github.event.pull_request.title }}
-            ${{ github.event.pull_request.body }}
+            Rules:
+            - "comments" should reference only lines that exist in the PR's head (RIGHT) side.
+            - Omit entries you cannot confidently map to a concrete file/line.
+            - Keep JSON valid and minified (no newlines beyond JSON needs).
 
   post_feedback:
     runs-on: ubuntu-latest
     needs: codex
-    if: needs.codex.outputs.final_message != ''
+    if: needs.codex.outputs.codex_json != ''
     permissions:
-      issues: write
       pull-requests: write
+      contents: read
     steps:
-      - name: Report Codex feedback
+      - name: Parse Codex JSON
+        id: parse
+        env:
+          CODEX_JSON: ${{ needs.codex.outputs.codex_json }}
+        run: |
+          set -e
+          echo "$CODEX_JSON" | jq -e . >/dev/null
+          echo "summary=$(echo "$CODEX_JSON" | jq -r '.summary // ""')" >> "$GITHUB_OUTPUT"
+          echo "comments=$(echo "$CODEX_JSON" | jq -c '.comments // []')" >> "$GITHUB_OUTPUT"
+
+      - name: Post inline review comments (chunked)
         uses: actions/github-script@v7
         env:
-          CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+          COMMENTS_JSON: ${{ steps.parse.outputs.comments }}
+          SUMMARY_TEXT: ${{ steps.parse.outputs.summary }}
         with:
           github-token: ${{ github.token }}
           script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: process.env.CODEX_FINAL_MESSAGE,
-            });
+            const prNumber = context.payload.pull_request.number;
+            const headSha = context.payload.pull_request.head.sha;
+
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+            const chunk = (arr, size) => {
+              const out = [];
+              for (let i=0;i<arr.length;i+=size) out.push(arr.slice(i, i+size));
+              return out;
+            };
+
+            const summary = (process.env.SUMMARY_TEXT || "").trim();
+            if (summary) {
+              await github.rest.pulls.createReview({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+                event: "COMMENT",
+                body: `Codex summary:\n\n${summary}`
+              });
+            }
+
+            let comments = [];
+            try {
+              comments = JSON.parse(process.env.COMMENTS_JSON || "[]");
+            } catch { comments = []; }
+
+            const TOTAL_MAX = 300;
+            comments = comments.slice(0, TOTAL_MAX);
+
+            const CHUNK_SIZE = 25;
+            const PAUSE_BETWEEN_CHUNKS_MS = 2500; // 2.5s delay
+            const chunks = chunk(comments, CHUNK_SIZE);
+
+            for (const group of chunks) {
+              for (const c of group) {
+                if (!c?.path || !Number.isInteger(c.line) || c.line <= 0) continue;
+                const title = c.title ? `**${c.title}**\n\n` : "";
+                const body = `${title}${c.body || ""}`.trim();
+                if (!body) continue;
+
+                // Retry on 403 abuse / rate-limit
+                let attempts = 0;
+                while (attempts < 3) {
+                  try {
+                    await github.rest.pulls.createReviewComment({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      pull_number: prNumber,
+                      commit_id: headSha,
+                      path: c.path,
+                      side: "RIGHT",
+                      line: c.line,
+                      body
+                    });
+                    break; // OK
+                  } catch (err) {
+                    const retryAfter = Number(err?.response?.headers?.['retry-after'] || 0);
+                    const status = err?.status || err?.response?.status;
+                    // 403 (abuse) or 429/secondary-rate — wait and retry
+                    if (status === 403 || status === 429) {
+                      await sleep((retryAfter ? retryAfter * 1000 : 3000) * (attempts + 1));
+                      attempts++;
+                      continue;
+                    }
+                    // Skip not in diff
+                    if (String(err?.message || '').includes('position') || String(err?.message || '').includes('line must be part of the diff')) {
+                      core.warning(`Skip ${c.path}:${c.line} — not in diff`);
+                      break;
+                    }
+                    core.warning(`Failed ${c.path}:${c.line}: ${err?.message || err}`);
+                    break;
+                  }
+                }
+              }
+              await sleep(PAUSE_BETWEEN_CHUNKS_MS);
+            }

--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       codex_json: ${{ steps.run_codex.outputs['final-message'] }}
     steps:

--- a/.github/workflows/test-pr-event.yml
+++ b/.github/workflows/test-pr-event.yml
@@ -1,0 +1,47 @@
+name: Test PR Event Logger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, review_requested]
+
+jobs:
+  log-event:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Log github.event object
+        run: |
+          echo "========================================="
+          echo "Full github.event object:"
+          echo "========================================="
+          echo '${{ toJSON(github.event) }}' | jq '.'
+
+      - name: Log specific PR details
+        run: |
+          echo "========================================="
+          echo "Pull Request Details:"
+          echo "========================================="
+          echo "PR Number: ${{ github.event.pull_request.number }}"
+          echo "PR Title: ${{ github.event.pull_request.title }}"
+          echo "PR State: ${{ github.event.pull_request.state }}"
+          echo "PR Action: ${{ github.event.action }}"
+          echo ""
+          echo "Base Branch: ${{ github.event.pull_request.base.ref }}"
+          echo "Base SHA: ${{ github.event.pull_request.base.sha }}"
+          echo ""
+          echo "Head Branch: ${{ github.event.pull_request.head.ref }}"
+          echo "Head SHA: ${{ github.event.pull_request.head.sha }}"
+          echo ""
+          echo "Author: ${{ github.event.pull_request.user.login }}"
+          echo "Draft: ${{ github.event.pull_request.draft }}"
+          echo "Mergeable: ${{ github.event.pull_request.mergeable }}"
+          echo "Merged: ${{ github.event.pull_request.merged }}"
+
+      - name: Log all available github context
+        run: |
+          echo "========================================="
+          echo "Full github context:"
+          echo "========================================="
+          echo '${{ toJSON(github) }}' | jq '.'


### PR DESCRIPTION
## Summary
- Added new GitHub Action workflow to log and debug pull request event data
- Logs the complete `github.event` object for PR events
- Logs specific PR details (number, title, branches, SHAs, author, etc.)
- Useful for understanding what data is available in PR events

## Test plan
- Create this PR and check the Actions tab to see the logged event data
- Verify all PR event details are properly logged